### PR TITLE
Fix unsafe YAML loading

### DIFF
--- a/crits/core/crits_mongoengine.py
+++ b/crits/core/crits_mongoengine.py
@@ -690,7 +690,7 @@ class CritsDocument(BaseDocument):
                   :class:`crits.core.crits_mongoengine.CritsBaseAttributes`
         """
 
-        return cls._from_son(yaml.load(yaml_data))
+        return cls._from_son(yaml.safe_load(yaml_data))
 
     def to_yaml(self, exclude=[]):
         """
@@ -701,7 +701,7 @@ class CritsDocument(BaseDocument):
         :returns: json
         """
 
-        return yaml.dump(yaml.load(self._json_yaml_convert(exclude)),
+        return yaml.dump(yaml.safe_load(self._json_yaml_convert(exclude)),
             default_flow_style=False)
 
     def __str__(self):

--- a/crits/core/data_tools.py
+++ b/crits/core/data_tools.py
@@ -330,7 +330,7 @@ def format_object(obj_type, obj_id, data_format="yaml", cleanse=True,
     data = json.dumps(convert_datetimes_to_string(data),
                       default=json_util.default)
     if data_format == "yaml":
-        data = yaml.dump(yaml.load(data), default_flow_style=False)
+        data = yaml.dump(yaml.safe_load(data), default_flow_style=False)
     elif data_format == "json":
         data = json.dumps(json.loads(data))
 

--- a/crits/emails/handlers.py
+++ b/crits/emails/handlers.py
@@ -729,7 +729,7 @@ def handle_yaml(data, sourcename, reference, method, tlp, user, email_id=None,
           }
 
     try:
-        converted = yaml.load(data)
+        converted = yaml.safe_load(data)
         if isinstance(converted, dict) == False:
             raise
     except Exception, e:


### PR DESCRIPTION
## Summary
- use `yaml.safe_load` when parsing user data

## Testing
- `python -m py_compile crits/emails/handlers.py crits/core/data_tools.py crits/core/crits_mongoengine.py` *(fails: SyntaxError)*
- `flake8 crits/emails/handlers.py crits/core/data_tools.py crits/core/crits_mongoengine.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fd3ffae2c8327899d93e083c93684