### PR TITLE
Bootstrap CRITs Next React/GraphQL version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ INSTALL_RECEIPT.json
 
 # Ignore VirtualEnv
 venv/*
+crits_next/frontend/node_modules/
+crits_next/backend/.venv/
+

--- a/README.md
+++ b/README.md
@@ -48,3 +48,9 @@ If you are looking for a more permanent and performant CRITs installation or jus
 We recommend adding services to your CRITs install. Services extend the features and functionality of the core project allowing you to enhance CRITs based on your needs. You can find more information about how to do this [here](https://github.com/crits/crits/wiki/Adding-services-to-CRITs).
 
 **Thanks for using CRITs!**
+
+## CRITs Next
+
+A new experimental version targeting Python 3.12+ with a React + GraphQL stack is being developed in the [`crits_next`](crits_next/) directory. Contributions are welcome!
+
+

--- a/crits_next/README.md
+++ b/crits_next/README.md
@@ -1,0 +1,11 @@
+# CRITs Next
+
+This directory contains an experimental rewrite of CRITs using modern technologies. The goal is to create a Python 3.12+ backend powered by FastAPI and GraphQL with a React-based frontend.
+
+## Structure
+
+- `backend/` – FastAPI project exposing a basic GraphQL endpoint.
+- `frontend/` – React application bootstrapped with Vite.
+
+Both sides are intentionally minimal to provide a starting point for further development.
+

--- a/crits_next/backend/README.md
+++ b/crits_next/backend/README.md
@@ -1,0 +1,20 @@
+# CRITs Next Backend
+
+This is a minimal FastAPI project exposing a GraphQL API using Strawberry.
+
+## Requirements
+
+- Python 3.12+
+- Dependencies from `requirements.txt`
+
+## Running locally
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+uvicorn app.main:app --reload
+```
+
+The API will be available at `http://localhost:8000/graphql`.
+

--- a/crits_next/backend/app/main.py
+++ b/crits_next/backend/app/main.py
@@ -1,0 +1,20 @@
+from fastapi import FastAPI
+import strawberry
+from strawberry.fastapi import GraphQLRouter
+
+@strawberry.type
+class Query:
+    hello: str = "Hello, CRITs Next!"
+
+schema = strawberry.Schema(query=Query)
+
+graphql_app = GraphQLRouter(schema)
+
+app = FastAPI(title="CRITs Next API")
+app.include_router(graphql_app, prefix="/graphql")
+
+
+@app.get("/")
+async def read_root():
+    return {"message": "Welcome to CRITs Next"}
+

--- a/crits_next/backend/requirements.txt
+++ b/crits_next/backend/requirements.txt
@@ -1,0 +1,3 @@
+fastapi
+uvicorn
+strawberry-graphql

--- a/crits_next/frontend/README.md
+++ b/crits_next/frontend/README.md
@@ -1,0 +1,15 @@
+# CRITs Next Frontend
+
+This directory contains a minimal React application bootstrapped with Vite. It communicates with the GraphQL backend using Apollo Client.
+
+## Getting started
+
+Install dependencies with your preferred package manager and start the development server:
+
+```bash
+npm install
+npm run dev
+```
+
+The application will be available at `http://localhost:3000` and expects the backend running at `http://localhost:8000`.
+

--- a/crits_next/frontend/index.html
+++ b/crits_next/frontend/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <title>CRITs Next</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/crits_next/frontend/package.json
+++ b/crits_next/frontend/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "crits-next-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@apollo/client": "^3.7.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.0.0",
+    "vite": "^4.0.0"
+  }
+}

--- a/crits_next/frontend/src/App.jsx
+++ b/crits_next/frontend/src/App.jsx
@@ -1,0 +1,20 @@
+import { gql, useQuery } from '@apollo/client';
+
+const HELLO_QUERY = gql`
+  query Hello {
+    hello
+  }
+`;
+
+export default function App() {
+  const { data, loading, error } = useQuery(HELLO_QUERY);
+
+  if (loading) return <p>Loading...</p>;
+  if (error) return <p>Error: {error.message}</p>;
+
+  return (
+    <div>
+      <h1>{data.hello}</h1>
+    </div>
+  );
+}

--- a/crits_next/frontend/src/main.jsx
+++ b/crits_next/frontend/src/main.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { ApolloClient, InMemoryCache, ApolloProvider } from '@apollo/client';
+import App from './App';
+
+const client = new ApolloClient({
+  uri: 'http://localhost:8000/graphql',
+  cache: new InMemoryCache(),
+});
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <ApolloProvider client={client}>
+      <App />
+    </ApolloProvider>
+  </React.StrictMode>
+);

--- a/crits_next/frontend/vite.config.js
+++ b/crits_next/frontend/vite.config.js
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 3000
+  }
+});


### PR DESCRIPTION
## Summary
- start a parallel project in `crits_next` to explore a modern stack
- add FastAPI/GraphQL backend
- add React frontend using Apollo and Vite
- mention the new project in the root README
- ignore frontend `node_modules` and backend virtual envs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68700dc546d0832797e65414ed24db26