### PR TITLE
feat: switch to GitHub OAuth and persist SQLite data

### DIFF
--- a/crits_next/README.md
+++ b/crits_next/README.md
@@ -9,10 +9,10 @@ This directory contains an experimental rewrite of CRITs using modern technologi
 
 Both sides are intentionally minimal to provide a starting point for further development.
 
-## User management and Google auth
+## User management and GitHub auth
 
 The example application now includes a very small user management system. Users can
-authenticate with Google, and their preferences and permissions are stored in the
+authenticate with GitHub, and their preferences and permissions are stored in the
 backend. An administrator panel in the React frontend allows viewing and updating
 these details.
 
@@ -25,6 +25,8 @@ cd crits_next
 docker compose up --build
 ```
 
-The frontend will be available on `http://localhost:3000` and expects a Google OAuth
-client id provided via the `VITE_GOOGLE_CLIENT_ID` environment variable.
+The frontend will be available on `http://localhost:3000` and expects a GitHub OAuth
+client id provided via the `VITE_GITHUB_CLIENT_ID` environment variable. The backend
+expects `GITHUB_CLIENT_ID` and `GITHUB_CLIENT_SECRET`. User data is stored in an
+SQLite database at `/data/users.db`, which is persisted using a Docker volume.
 

--- a/crits_next/backend/README.md
+++ b/crits_next/backend/README.md
@@ -13,7 +13,7 @@ This is a minimal FastAPI project exposing a GraphQL API using Strawberry.
 python -m venv .venv
 source .venv/bin/activate
 pip install -r requirements.txt
-uvicorn app.main:app --reload
+GITHUB_CLIENT_ID=your_id GITHUB_CLIENT_SECRET=your_secret uvicorn app.main:app --reload
 ```
 
 The API will be available at `http://localhost:8000/graphql`.

--- a/crits_next/backend/app/main.py
+++ b/crits_next/backend/app/main.py
@@ -1,13 +1,31 @@
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
 from typing import Dict, List
-from google.oauth2 import id_token
-from google.auth.transport import requests as grequests
+import os
+import json
+import sqlite3
+import requests
 import strawberry
 from strawberry.fastapi import GraphQLRouter
 from strawberry.scalars import JSON
 
 app = FastAPI(title="CRITs Next API")
+
+DB_PATH = os.environ.get("DATABASE_PATH", "/data/users.db")
+conn = sqlite3.connect(DB_PATH, check_same_thread=False)
+cur = conn.cursor()
+cur.execute(
+    """
+    CREATE TABLE IF NOT EXISTS users (
+        id TEXT PRIMARY KEY,
+        email TEXT,
+        preferences TEXT,
+        permissions TEXT
+    )
+    """
+)
+conn.commit()
+
 
 class User(BaseModel):
     id: str
@@ -16,21 +34,75 @@ class User(BaseModel):
     permissions: List[str] = []
 
 
-users_db: Dict[str, User] = {}
+def get_user(uid: str) -> User | None:
+    cur.execute(
+        "SELECT id, email, preferences, permissions FROM users WHERE id=?",
+        (uid,),
+    )
+    row = cur.fetchone()
+    if row:
+        return User(
+            id=row[0],
+            email=row[1],
+            preferences=json.loads(row[2] or "{}"),
+            permissions=json.loads(row[3] or "[]"),
+        )
+    return None
 
 
-@app.post("/auth/google")
-async def auth_google(token: str):
+def save_user(user: User) -> None:
+    cur.execute(
+        """
+        INSERT OR REPLACE INTO users (id, email, preferences, permissions)
+        VALUES (?, ?, ?, ?)
+        """,
+        (
+            user.id,
+            user.email,
+            json.dumps(user.preferences),
+            json.dumps(user.permissions),
+        ),
+    )
+    conn.commit()
+
+
+GITHUB_CLIENT_ID = os.environ.get("GITHUB_CLIENT_ID")
+GITHUB_CLIENT_SECRET = os.environ.get("GITHUB_CLIENT_SECRET")
+
+
+@app.post("/auth/github")
+async def auth_github(code: str):
     try:
-        idinfo = id_token.verify_oauth2_token(token, grequests.Request())
+        token_res = requests.post(
+            "https://github.com/login/oauth/access_token",
+            data={
+                "client_id": GITHUB_CLIENT_ID,
+                "client_secret": GITHUB_CLIENT_SECRET,
+                "code": code,
+            },
+            headers={"Accept": "application/json"},
+            timeout=10,
+        )
+        token_res.raise_for_status()
+        access_token = token_res.json().get("access_token")
+        if not access_token:
+            raise ValueError("No access token returned")
+        user_res = requests.get(
+            "https://api.github.com/user",
+            headers={"Authorization": f"Bearer {access_token}"},
+            timeout=10,
+        )
+        user_res.raise_for_status()
+        user_json = user_res.json()
     except Exception:
-        raise HTTPException(status_code=400, detail="Invalid Google token")
-    uid = idinfo["sub"]
-    email = idinfo.get("email", "")
-    user = users_db.get(uid)
+        raise HTTPException(status_code=400, detail="Invalid GitHub code")
+
+    uid = str(user_json.get("id"))
+    email = user_json.get("email") or ""
+    user = get_user(uid)
     if not user:
         user = User(id=uid, email=email)
-        users_db[uid] = user
+    save_user(user)
     return user
 
 
@@ -43,23 +115,51 @@ class UserType:
 
 
 def list_users() -> List[UserType]:
-    return [UserType(id=u.id, email=u.email, preferences=u.preferences, permissions=u.permissions) for u in users_db.values()]
+    cur.execute("SELECT id, email, preferences, permissions FROM users")
+    rows = cur.fetchall()
+    return [
+        UserType(
+            id=row[0],
+            email=row[1],
+            preferences=json.loads(row[2] or "{}"),
+            permissions=json.loads(row[3] or "[]"),
+        )
+        for row in rows
+    ]
 
 
 def mutate_preferences(id: str, preferences: JSON) -> UserType:
-    user = users_db.get(id)
+    cur.execute(
+        "UPDATE users SET preferences=? WHERE id=?",
+        (json.dumps(preferences), id),
+    )
+    conn.commit()
+    user = get_user(id)
     if not user:
         raise ValueError("User not found")
-    user.preferences = preferences
-    return UserType(id=user.id, email=user.email, preferences=user.preferences, permissions=user.permissions)
+    return UserType(
+        id=user.id,
+        email=user.email,
+        preferences=user.preferences,
+        permissions=user.permissions,
+    )
 
 
 def mutate_permissions(id: str, permissions: List[str]) -> UserType:
-    user = users_db.get(id)
+    cur.execute(
+        "UPDATE users SET permissions=? WHERE id=?",
+        (json.dumps(permissions), id),
+    )
+    conn.commit()
+    user = get_user(id)
     if not user:
         raise ValueError("User not found")
-    user.permissions = permissions
-    return UserType(id=user.id, email=user.email, preferences=user.preferences, permissions=user.permissions)
+    return UserType(
+        id=user.id,
+        email=user.email,
+        preferences=user.preferences,
+        permissions=user.permissions,
+    )
 
 
 @strawberry.type

--- a/crits_next/backend/requirements.txt
+++ b/crits_next/backend/requirements.txt
@@ -1,5 +1,4 @@
 fastapi
 uvicorn
 strawberry-graphql
-google-auth
 requests

--- a/crits_next/docker-compose.yml
+++ b/crits_next/docker-compose.yml
@@ -2,13 +2,21 @@ version: '3'
 services:
   backend:
     build: ./backend
+    environment:
+      - GITHUB_CLIENT_ID=${GITHUB_CLIENT_ID}
+      - GITHUB_CLIENT_SECRET=${GITHUB_CLIENT_SECRET}
+    volumes:
+      - db-data:/data
     ports:
       - "8000:8000"
   frontend:
     build: ./frontend
     environment:
-      - VITE_GOOGLE_CLIENT_ID=${VITE_GOOGLE_CLIENT_ID}
+      - VITE_GITHUB_CLIENT_ID=${VITE_GITHUB_CLIENT_ID}
     ports:
       - "3000:3000"
     depends_on:
       - backend
+
+volumes:
+  db-data:

--- a/crits_next/frontend/README.md
+++ b/crits_next/frontend/README.md
@@ -8,7 +8,7 @@ Install dependencies with your preferred package manager and start the developme
 
 ```bash
 npm install
-npm run dev
+VITE_GITHUB_CLIENT_ID=your_id npm run dev
 ```
 
 The application will be available at `http://localhost:3000` and expects the backend running at `http://localhost:8000`.

--- a/crits_next/frontend/package.json
+++ b/crits_next/frontend/package.json
@@ -9,9 +9,9 @@
   },
   "dependencies": {
     "@apollo/client": "^3.7.0",
-    "@react-oauth/google": "^0.11.0",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "react-github-login": "^0.6.0"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.0.0",

--- a/crits_next/frontend/src/App.jsx
+++ b/crits_next/frontend/src/App.jsx
@@ -1,15 +1,15 @@
-import { GoogleLogin } from '@react-oauth/google';
+import GitHubLogin from 'react-github-login';
 import { useState } from 'react';
 import AdminPanel from './AdminPanel';
 
 export default function App() {
   const [user, setUser] = useState(null);
 
-  const handleSuccess = async (credentialResponse) => {
-    const res = await fetch('http://localhost:8000/auth/google', {
+  const handleSuccess = async (response) => {
+    const res = await fetch('http://localhost:8000/auth/github', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ token: credentialResponse.credential }),
+      body: JSON.stringify({ code: response.code }),
     });
     const data = await res.json();
     setUser(data);
@@ -21,7 +21,11 @@ export default function App() {
       {user ? (
         <AdminPanel />
       ) : (
-        <GoogleLogin onSuccess={handleSuccess} onError={() => console.log('Login Failed')} />
+        <GitHubLogin
+          clientId={import.meta.env.VITE_GITHUB_CLIENT_ID}
+          onSuccess={handleSuccess}
+          onFailure={() => console.log('Login Failed')}
+        />
       )}
     </div>
   );

--- a/crits_next/frontend/src/main.jsx
+++ b/crits_next/frontend/src/main.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { ApolloClient, InMemoryCache, ApolloProvider } from '@apollo/client';
-import { GoogleOAuthProvider } from '@react-oauth/google';
 import App from './App';
 
 const client = new ApolloClient({
@@ -9,14 +8,10 @@ const client = new ApolloClient({
   cache: new InMemoryCache(),
 });
 
-const clientId = import.meta.env.VITE_GOOGLE_CLIENT_ID;
-
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
-    <GoogleOAuthProvider clientId={clientId}>
-      <ApolloProvider client={client}>
-        <App />
-      </ApolloProvider>
-    </GoogleOAuthProvider>
+    <ApolloProvider client={client}>
+      <App />
+    </ApolloProvider>
   </React.StrictMode>,
 );


### PR DESCRIPTION
## Summary
- replace Google authentication with GitHub OAuth
- persist user records in a SQLite database and mount it via Docker volume
- update frontend and documentation for GitHub login

## Testing
- `python -m py_compile crits_next/backend/app/main.py`
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/react-github-login)*
- `npm run build` *(fails: Rollup failed to resolve import "react-github-login")*

------
https://chatgpt.com/codex/tasks/task_e_68b1aca84ca48327b3d79d16acff1768