### PR TITLE
chore: pnpm security hardening, UI cache and sidebar fixes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 # Pre-commit hooks for CRITs
-# Install: pip install pre-commit && pre-commit install
+# Install: uv tool install pre-commit && pre-commit install
 # Run manually: pre-commit run --all-files
 
 repos:

--- a/docker/Dockerfile.ui
+++ b/docker/Dockerfile.ui
@@ -2,12 +2,12 @@
 FROM node:20-alpine AS builder
 
 # Enable corepack and activate the exact pnpm version from package.json
-RUN corepack enable && corepack prepare pnpm@10.28.2 --activate
+RUN corepack enable && corepack prepare pnpm@10.32.1 --activate
 
 WORKDIR /app
 
-# Copy package files
-COPY ui/package.json ui/pnpm-lock.yaml* ./
+# Copy package files and security config
+COPY ui/package.json ui/pnpm-lock.yaml ui/.npmrc ./
 
 # Install dependencies with pnpm (frozen lockfile for reproducibility)
 RUN pnpm install --frozen-lockfile

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -127,5 +127,8 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
+        # Prevent caching index.html so new builds are picked up immediately
+        add_header Cache-Control "no-cache, no-store, must-revalidate";
+        add_header Pragma "no-cache";
     }
 }

--- a/ui/.npmrc
+++ b/ui/.npmrc
@@ -1,3 +1,7 @@
 # Enforce pnpm for supply chain security
 # Do NOT use npm install - use pnpm install instead
 engine-strict=true
+strict-peer-dependencies=true
+auto-install-peers=false
+resolve-peers-from-workspace-root=false
+side-effects-cache=true

--- a/ui/package.json
+++ b/ui/package.json
@@ -3,10 +3,10 @@
   "version": "0.1.0",
   "private": true,
   "type": "module",
-  "packageManager": "pnpm@10.28.2",
+  "packageManager": "pnpm@10.32.1+sha512.a706938f0e89ac1456b6563eab4edf1d1faf3368d1191fc5c59790e96dc918e4456ab2e67d613de1043d2e8c81f87303e6b40d4ffeca9df15ef1ad567348f2be",
   "engines": {
     "node": ">=20",
-    "pnpm": ">=10"
+    "pnpm": "10.32.1"
   },
   "scripts": {
     "preinstall": "npx only-allow pnpm",

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -1,7 +1,7 @@
 lockfileVersion: '9.0'
 
 settings:
-  autoInstallPeers: true
+  autoInstallPeers: false
   excludeLinksFromLockfile: false
 
 importers:

--- a/ui/src/components/layout/Sidebar.tsx
+++ b/ui/src/components/layout/Sidebar.tsx
@@ -46,10 +46,11 @@ interface SystemItem {
 }
 
 const SYSTEM_ITEMS: SystemItem[] = [
-  { label: 'Tags', route: '/tags', icon: Tag },
-  { label: 'Services', route: '/services', icon: Wrench },
-  { label: 'Sources', route: '/sources', icon: Database },
+  { label: 'Users', route: '/users', icon: Users },
   { label: 'Roles', route: '/roles', icon: Shield },
+  { label: 'Sources', route: '/sources', icon: Database },
+  { label: 'Services', route: '/services', icon: Wrench },
+  { label: 'Tags', route: '/tags', icon: Tag },
   { label: 'Config', route: '/config-items', icon: Settings2 },
 ]
 
@@ -231,7 +232,6 @@ export function Sidebar({ isOpen, onClose }: SidebarProps) {
             label={TLO_CONFIGS.Indicator.label}
             onNavigate={onClose}
           />
-          <SidebarLink to="/users" icon={Users} label="Users" onNavigate={onClose} />
           <SidebarLink to="/chat" icon={MessageSquare} label="AI Chat" onNavigate={onClose} />
 
           {/* Divider */}

--- a/ui/src/pages/RolesPage.tsx
+++ b/ui/src/pages/RolesPage.tsx
@@ -572,8 +572,9 @@ export function RolesPage() {
   })
 
   const { data: sourcesData } = useQuery({
-    queryKey: ['sources'],
+    queryKey: ['sources', 'names'],
     queryFn: () => gqlQuery<{ sources: SourceBasic[] }>(SOURCES_QUERY),
+    staleTime: 0, // Always refetch — sources may have been created on another page
   })
 
   const toggleRole = useMutation({

--- a/ui/src/pages/SourcesPage.tsx
+++ b/ui/src/pages/SourcesPage.tsx
@@ -103,7 +103,7 @@ function CreateSourceDialog({ open, onClose }: { open: boolean; onClose: () => v
     onSuccess: (data) => {
       const res = data.createSource
       if (res.success) {
-        queryClient.invalidateQueries({ queryKey: ['sources'] })
+        queryClient.invalidateQueries({ queryKey: ['sources'] }) // SourcesPage + RolesPage
         setName('')
         setResult({ type: 'success', text: res.message })
         setTimeout(() => onClose(), 1000)


### PR DESCRIPTION
## Summary
- Update pnpm to 10.32.1 with SHA-512 integrity hash and pin exact version in engines + Dockerfile
- Add strict security settings to `.npmrc` (strict-peer-dependencies, no auto-install-peers)
- Fix outer nginx missing `no-cache` headers on `index.html` — browser was serving stale JS bundles after rebuilds
- Move Users link into System sidebar section
- Fix RolesPage not showing newly created sources (shared query key + 5min staleTime caused stale cache)
- Fix pre-commit config comment to reference `uv` instead of `pip`

## Test plan
- [x] `pnpm install --frozen-lockfile` succeeds with new settings
- [x] Docker build succeeds with updated Dockerfile
- [x] All 67 tests pass
- [x] Hard refresh loads new assets immediately after rebuild
- [x] Users appears under System in sidebar
- [x] Creating a source on Sources page, then navigating to Roles shows it in the dropdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)